### PR TITLE
Update example_network.py

### DIFF
--- a/example_network.py
+++ b/example_network.py
@@ -1,7 +1,7 @@
 from m5stack import *
 from m5ui import *
 from uiflow import *
-from microWebSrv import MicroWebSrv
+from MicroWebSrv import microWebSrv
 import wifiCfg
 import ubinascii
 rgb.setColorAll(0xff0000)

--- a/example_network.py
+++ b/example_network.py
@@ -1,7 +1,7 @@
 from m5stack import *
 from m5ui import *
 from uiflow import *
-from MicroWebSrv import microWebSrv
+from MicroWebSrv.microWebSrv import MicroWebSrv
 import wifiCfg
 import ubinascii
 rgb.setColorAll(0xff0000)


### PR DESCRIPTION
"from MicroWebSrv.microWebSrv import MicroWebSrv" is correct under UiFLOW of M5AtomMatrix v1.7.3 and M5StickC v1.7.4.